### PR TITLE
Added new features to allow multiple data series

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,19 @@ A Ruby library for generating plain text x,y cartesian plots and histograms that
 
 ## Unfeatures
 
- * No more than one data series per chart
  * Data must be pre-sorted 
  * x axis will not be continuous if your data isn't
  * Only x,y point graphs and bar histograms supported
  * Minimal configuration options
+
+## Update in 0.9.2
+
+ * Now supports a different way of passing the inputs
+ * Supports more than one data series per chart   
+   In the case of bar chart, the values will be stacked according to data sequence. 
+ * Supports the selection of marker characters
+   User can specify one marker, in which case all line sequences will use that marker. Or user can specify marker at least the same number as the number of data series. 
+ * Now allows nil in the y-values, in which case the corresponding point will be left blank 
 
 ## Install
 
@@ -112,4 +120,64 @@ A Ruby library for generating plain text x,y cartesian plots and histograms that
      0.0+-*--*--*--*--*--*--*--*--*--*--*--*--*--*--*--*--*--*--*--*-
           0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19 
 
+    ## draw a line with multiple data series. Argument format is (x-array, y1-array... ym-array, options)
+    puts AsciiCharts::Cartesian.new([0, 1, 2, 3], [10, 20, nil, 25], [5, 0, 5, 10], :markers => ['*','x']).draw
 
+    26|      *
+    24|
+    22|
+    20|  *
+    18|
+    16|
+    14|
+    12|
+    10|*     x
+     8|
+     6|x   x
+     4|
+     2|
+     0+--x-----
+       0 1 2 3
+
+    ## draw a bar chart for multiple series
+    puts AsciiCharts::Cartesian.new([0, 1, 2], [1, 10, 4], [2, 0, 6], [2, 1, 6], :bar => true, :hide_zero => true, :markers => ['*','o','x']).draw
+
+    16|    x
+    15|    x
+    14|    x
+    13|    x
+    12|    x
+    11|  x x
+    10|  * o
+     9|  * o
+     8|  * o
+     7|  * o
+     6|  * o
+     5|x * o
+     4|x * *
+     3|o * *
+     2|o * *
+     1|* * *
+     0+------
+       0 1 2
+
+    ## alternative way of insert multiple series. Argument format is ([[x1 with y's], ...[xn with y's]], options) 
+    puts AsciiCharts::Cartesian.new([[0, 1, 2, 2], [1, 10, 0, 1], [2, 4, 6, 6]], :bar => true, :hide_zero => true, :markers => ['*','o','x']).draw
+    16|    x
+    15|    x
+    14|    x
+    13|    x
+    12|    x
+    11|  x x
+    10|  * o
+     9|  * o
+     8|  * o
+     7|  * o
+     6|  * o
+     5|x * o
+     4|x * *
+     3|o * *
+     2|o * *
+     1|* * *
+     0+------
+       0 1 2

--- a/ascii_charts.gemspec
+++ b/ascii_charts.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.description = 'Library to draw simple ASCII charts (x,y graph plots and histograms)'
   s.summary = 'Very simple API, your data may already in the correct format to be plotted. Dynamically scales the y-axis. Simple configuration options, including chart title.'
   s.email = 'ben@benlund.com'
-  s.homepage = 'http://github.com/bobbyliu/ascii_charts'
+  s.homepage = 'http://github.com/benlund/ascii_charts'
 
   s.files = ['lib/ascii_charts.rb']
 end

--- a/ascii_charts.gemspec
+++ b/ascii_charts.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.description = 'Library to draw simple ASCII charts (x,y graph plots and histograms)'
   s.summary = 'Very simple API, your data may already in the correct format to be plotted. Dynamically scales the y-axis. Simple configuration options, including chart title.'
   s.email = 'ben@benlund.com'
-  s.homepage = 'http://github.com/benlund/ascii_charts'
+  s.homepage = 'http://github.com/bobbyliu/ascii_charts'
 
   s.files = ['lib/ascii_charts.rb']
 end

--- a/lib/ascii_charts.rb
+++ b/lib/ascii_charts.rb
@@ -1,6 +1,6 @@
 module AsciiCharts
 
-  VERSION = '0.9.1'
+  VERSION = '0.9.2'
 
   class Chart
 
@@ -11,11 +11,11 @@ module AsciiCharts
 
     #data is a sorted array of [x, y] pairs
 
-    def initialize(data, options={})
+    def initialize(data, options={})      
+      puts data
       @data = data
       @options = options
     end
-
 
     def rounded_data
       @rounded_data ||= self.data.map{|pair| [pair[0], self.round_value(pair[1])]}
@@ -248,7 +248,7 @@ module AsciiCharts
           marker = if (0 == i) && options[:hide_zero]
                      '-'
                    else
-                     '*'
+                     'o'
                    end
           filler = if 0 == i
                      '-'

--- a/lib/ascii_charts.rb
+++ b/lib/ascii_charts.rb
@@ -45,18 +45,6 @@ module AsciiCharts
       end      
     end
 
-    def bar_reduction()
-      @data.each do |series|
-        cur_sum = 0
-        for i in (1..series.length - 1)
-          if series[i]
-            cur_sum = cur_sum + series[i]
-            series[i] = cur_sum
-          end
-        end
-      end
-    end
-
     def rounded_data
       @rounded_data ||= self.data.map{|pair| [pair[0], pair[1.. (pair.length - 1)].map{|y| y && self.round_value(y)}].flatten! }
     end


### PR DESCRIPTION
## Update in 0.9.2
- Now supports a different way of passing the inputs
- Supports more than one data series per chart  
  In the case of bar chart, the values will be stacked according to data sequence. 
- Supports the selection of marker characters
  User can specify one marker, in which case all line sequences will use that marker. Or user can specify marker at least the same number as the number of data series. 
- Now allows nil in the y-values, in which case the corresponding point will be left blank 
